### PR TITLE
Update actions/upload-artifact to latest version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,14 +35,14 @@ jobs:
         make latexpdf || echo "PDF build failed, continuing..."
     
     - name: Upload HTML documentation
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: documentation-html
         path: docs/_build/html/
         retention-days: 30
     
     - name: Upload PDF documentation
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: documentation-pdf
@@ -67,13 +67,13 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Download HTML documentation
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: documentation-html
         path: documentation-html
     
     - name: Download PDF documentation
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: documentation-pdf
         path: documentation-pdf


### PR DESCRIPTION
Update GitHub Actions `upload-artifact` and `download-artifact` to v4 to resolve deprecation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-6633edfa-0836-4498-808a-4a79ff1efb87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6633edfa-0836-4498-808a-4a79ff1efb87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

